### PR TITLE
Prevent None paths from breaking code in get_url.

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -466,7 +466,7 @@ class Storage:
         # remove leading backlash
         url = self.get_url(token)
         if path.startswith('/'):
-            path = path[1:]
+            path = path.lstrip('/')
         if self.credentials:
             blob = self.bucket.get_blob(path)
             if not blob is None:
@@ -486,10 +486,10 @@ class Storage:
                         f.write(chunk)
 
     def get_url(self, token):
-        path = self.path
+        path = self.path if self.path else ''
         self.path = None
         if path.startswith('/'):
-            path = path[1:]
+            path = path.lstrip('/')
         if token:
             return "{0}/o/{1}?alt=media&token={2}".format(self.storage_bucket, quote(path, safe=''), token)
         return "{0}/o/{1}?alt=media".format(self.storage_bucket, quote(path, safe=''))


### PR DESCRIPTION
Added code to prevent None string values in Path from breaking code when getting urls of storage paths. Also ensured that we are removing all trailing "/" characters from paths when necessary by converting path = path[1:]  to path = path.lstrip('/')